### PR TITLE
Mobile multi-pane swipe UI for the game screen

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.18.3-otp-27
-erlang 27.3.3
+elixir 1.19.5-otp-28
+erlang 28.5

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -168,6 +168,24 @@ button:active:not(:disabled) {
 		min-height: 0;
 		padding: 0;
 	}
+
+	/* The track is position:fixed and <main> is neutralized above, so the
+	 * header is the only element left in document flow. Left static it
+	 * scrolls away while the fixed track stays — dragging anywhere just
+	 * slides the navbar on/off screen. Fix the header and lock the body:
+	 * with nothing in flow the document can't scroll, and each pane
+	 * scrolls its own content (pane 1's overflow-y-auto handles long
+	 * player-word lists). */
+	body:has(.mobile-pane-track) {
+		overflow: hidden;
+	}
+	body:has(.mobile-pane-track) header {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		z-index: 40;
+	}
 }
 
 .mobile-pane-dot {
@@ -185,4 +203,13 @@ button:active:not(:disabled) {
 .mobile-pane-dot.active {
 	opacity: 1;
 	transform: scale(1.3);
+}
+
+/* iOS Safari auto-zooms when focusing an input whose font-size is below
+ * 16px and never zooms back out. The chat input renders at text-sm
+ * (14px), so force it to 16px on mobile. Desktop keeps the compact size. */
+@media (max-width: 767px) {
+	#chat_message_input {
+		font-size: 16px;
+	}
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -117,3 +117,72 @@ html[data-theme="dark"] #themeSelectorWrapper {
 button:active:not(:disabled) {
 	box-shadow: var(--theme-button-shadow-active) !important;
 }
+
+/* Hide scrollbars but keep scrolling functional */
+.no-scrollbar {
+	scrollbar-width: none;
+	-ms-overflow-style: none;
+}
+.no-scrollbar::-webkit-scrollbar {
+	display: none;
+}
+
+/*
+ * Mobile two-pane swipe layout. Below the md breakpoint the track is
+ * position:fixed and fills the viewport below the header; each pane is
+ * a full-viewport horizontal scroll-snap stop. At md+ the track flips
+ * to a grid via Tailwind's md: utilities and the pane <section>s
+ * collapse via `md:contents`, so these rules only matter on mobile.
+ *
+ * The layout-track is rooted to the viewport via fixed positioning, so
+ * it sits independently of the parent <main>'s padding. The :has()
+ * rule below also neutralizes <main>'s min-h-screen + padding when the
+ * playing layout is present, so the page does not pick up phantom
+ * scroll height behind the fixed track.
+ */
+.mobile-pane-track {
+	position: fixed;
+	left: 0;
+	right: 0;
+	top: var(--header-h, 4rem);
+	bottom: 0;
+	scroll-snap-stop: always;
+	z-index: 1;
+}
+
+@media (min-width: 768px) {
+	.mobile-pane-track {
+		position: static;
+		top: auto;
+		left: auto;
+		right: auto;
+		bottom: auto;
+	}
+}
+
+/* When the playing layout is mounted, neutralize <main>'s min-h-screen
+ * and padding on mobile so the document doesn't grow past the viewport
+ * behind the fixed track. */
+@media (max-width: 767px) {
+	main:has(.mobile-pane-track) {
+		min-height: 0;
+		padding: 0;
+	}
+}
+
+.mobile-pane-dot {
+	width: 0.625rem;
+	height: 0.625rem;
+	border-radius: 9999px;
+	background-color: var(--theme-border);
+	opacity: 0.4;
+	transition: opacity 0.2s ease, transform 0.2s ease;
+	cursor: pointer;
+	border: none;
+	padding: 0;
+}
+
+.mobile-pane-dot.active {
+	opacity: 1;
+	transform: scale(1.3);
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -25,6 +25,7 @@ import {Hotkeys} from "./hooks/hotkeys"
 import {AutoScrollFeed} from "./hooks/auto_scroll_feed"
 import {TileFlipping} from "./hooks/tile_flipping"
 import {TabSwitcher} from "./hooks/tab_switcher"
+import {MobilePanes} from "./hooks/mobile_panes"
 import {ThemeSelector} from "./hooks/theme_selector"
 import {ThemeSelectorWrapper} from "./hooks/theme_selector_wrapper"
 import {SoundPlayer} from "./hooks/sound_player"
@@ -39,6 +40,7 @@ let liveSocket = new LiveSocket("/live", Socket, {
     AutoScrollFeed,
     TileFlipping,
     TabSwitcher,
+    MobilePanes,
     ThemeSelector,
     ThemeSelectorWrapper,
     SoundPlayer,

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,6 +26,7 @@ import {AutoScrollFeed} from "./hooks/auto_scroll_feed"
 import {TileFlipping} from "./hooks/tile_flipping"
 import {TabSwitcher} from "./hooks/tab_switcher"
 import {MobilePanes} from "./hooks/mobile_panes"
+import {FitRowOrStack} from "./hooks/fit_row_or_stack"
 import {ThemeSelector} from "./hooks/theme_selector"
 import {ThemeSelectorWrapper} from "./hooks/theme_selector_wrapper"
 import {SoundPlayer} from "./hooks/sound_player"
@@ -41,6 +42,7 @@ let liveSocket = new LiveSocket("/live", Socket, {
     TileFlipping,
     TabSwitcher,
     MobilePanes,
+    FitRowOrStack,
     ThemeSelector,
     ThemeSelectorWrapper,
     SoundPlayer,

--- a/assets/js/hooks/fit_row_or_stack.js
+++ b/assets/js/hooks/fit_row_or_stack.js
@@ -1,0 +1,47 @@
+// FitRowOrStack - LiveView Hook
+//
+// Lays the element's direct children out in a horizontal row when they
+// all fit within the element's width, and stacks them vertically when
+// they don't. Used for the Best Steal card: "old word -> new word" stays
+// on one line when there's room, otherwise each word drops onto its own
+// line (and scrolls individually via its own overflow-x).
+//
+// When there are exactly three children (word, arrow, word) the middle
+// one is rotated 90deg while stacked so the connecting arrow points down.
+export const FitRowOrStack = {
+  mounted() {
+    this.evaluate();
+    this.resizeObserver = new ResizeObserver(() => this.evaluate());
+    this.resizeObserver.observe(this.el);
+  },
+
+  updated() {
+    this.evaluate();
+  },
+
+  destroyed() {
+    if (this.resizeObserver) this.resizeObserver.disconnect();
+  },
+
+  evaluate() {
+    const items = Array.from(this.el.children);
+    if (items.length < 2) return;
+
+    // scrollWidth reports each child's natural content width even when the
+    // child is itself an overflow-x scroller, so this measures the true
+    // horizontal space a single-row layout would need.
+    const gap = parseFloat(getComputedStyle(this.el).columnGap) || 0;
+    const needed =
+      items.reduce((sum, el) => sum + el.scrollWidth, 0) +
+      gap * (items.length - 1);
+    const fits = needed <= this.el.clientWidth;
+
+    this.el.classList.toggle('flex-row', fits);
+    this.el.classList.toggle('flex-col', !fits);
+
+    // Point the connecting arrow (middle of three) down when stacked.
+    if (items.length === 3) {
+      items[1].style.transform = fits ? '' : 'rotate(90deg)';
+    }
+  }
+};

--- a/assets/js/hooks/mobile_panes.js
+++ b/assets/js/hooks/mobile_panes.js
@@ -1,0 +1,93 @@
+// MobilePanes - LiveView Hook
+//
+// Drives the mobile two-pane swipe layout. The track element is a
+// horizontal scroll-snap container fixed to the viewport on mobile and
+// a CSS grid on desktop (the panes use `md:contents` to collapse into
+// the grid). On desktop the IntersectionObserver still runs but the
+// dot indicators are hidden, so the cost is negligible.
+export const MobilePanes = {
+  mounted() {
+    this.dots = Array.from(document.querySelectorAll('[data-pane-dot]'));
+    this.panes = Array.from(this.el.querySelectorAll('[data-pane]'));
+
+    this.dotClickHandlers = [];
+    this.dots.forEach(dot => {
+      const handler = (event) => {
+        event.preventDefault();
+        this.scrollToPane(dot.dataset.paneDot);
+      };
+      dot.addEventListener('click', handler);
+      this.dotClickHandlers.push([dot, handler]);
+    });
+
+    // Track active pane by raw scroll position. IntersectionObserver with a
+    // single threshold races when two panes momentarily sit at exactly 50%,
+    // so the active dot can lag or pick the wrong pane. Reading scrollLeft
+    // directly is unambiguous.
+    if (this.panes.length > 0) {
+      this.onScroll = () => {
+        const width = this.el.clientWidth;
+        if (width === 0) return;
+        const idx = Math.round(this.el.scrollLeft / width);
+        const pane = this.panes[idx];
+        if (pane && pane.dataset.pane !== this.activePane) {
+          this.activePane = pane.dataset.pane;
+          this.setActiveDot(this.activePane);
+        }
+      };
+      this.el.addEventListener('scroll', this.onScroll, { passive: true });
+      // Run once on mount so the dot reflects the initial pane
+      this.onScroll();
+    }
+
+    // Track the header's bottom edge so the fixed-position track sits
+    // exactly under it. The header has variable height (progress bar
+    // is conditional, theme switcher row may wrap, etc.).
+    this.header = document.querySelector('header');
+    if (this.header) {
+      this.updateHeaderHeight = () => {
+        const rect = this.header.getBoundingClientRect();
+        document.documentElement.style.setProperty('--header-h', `${rect.bottom}px`);
+      };
+      this.updateHeaderHeight();
+      this.headerObserver = new ResizeObserver(this.updateHeaderHeight);
+      this.headerObserver.observe(this.header);
+      window.addEventListener('resize', this.updateHeaderHeight);
+    }
+
+    this.lastChallengeOpen = this.el.dataset.challengeOpen;
+  },
+
+  updated() {
+    // When a challenge opens, pull the user back to the primary pane so
+    // the modal lands in context with the tiles rather than over the chat.
+    const challengeOpen = this.el.dataset.challengeOpen;
+    if (challengeOpen === 'true' && this.lastChallengeOpen !== 'true') {
+      this.scrollToPane('primary');
+    }
+    this.lastChallengeOpen = challengeOpen;
+  },
+
+  scrollToPane(name) {
+    const pane = this.el.querySelector(`[data-pane="${name}"]`);
+    if (!pane) return;
+    this.el.scrollTo({ left: pane.offsetLeft, behavior: 'smooth' });
+  },
+
+  setActiveDot(name) {
+    this.dots.forEach(dot => {
+      dot.classList.toggle('active', dot.dataset.paneDot === name);
+    });
+  },
+
+  destroyed() {
+    if (this.onScroll) this.el.removeEventListener('scroll', this.onScroll);
+    if (this.headerObserver) this.headerObserver.disconnect();
+    if (this.updateHeaderHeight) {
+      window.removeEventListener('resize', this.updateHeaderHeight);
+    }
+    this.dotClickHandlers.forEach(([dot, handler]) => {
+      dot.removeEventListener('click', handler);
+    });
+  }
+};

--- a/config/config.exs
+++ b/config/config.exs
@@ -30,7 +30,7 @@ config :piratex,
   max_player_name: 15,
 
   # min and max team name length
-  min_team_name: 1,
+  min_team_name: 3,
   max_team_name: 15,
 
   # min word length

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -55,6 +55,11 @@ config :piratex, PiratexWeb.Endpoint,
 # Enable dev routes for dashboard and mailbox
 config :piratex, dev_routes: true
 
+# Force browsers to revalidate static assets every request in dev, so an
+# edited app.css/app.js is picked up immediately — no stale cache when
+# testing on a real device. Read by Plug.Static in PiratexWeb.Endpoint.
+config :piratex, static_cache_control: "no-cache"
+
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"
 

--- a/lib/piratex_web/components/game/playing.ex
+++ b/lib/piratex_web/components/game/playing.ex
@@ -179,7 +179,7 @@ defmodule PiratexWeb.Components.Playing do
     <%!-- Desktop view --%>
     <div
       id="board_center"
-      class="flex flex-wrap content-start gap-1 sm:gap-2 w-full max-h-40 md:h-40 overflow-y-auto overscroll-contain no-scrollbar rounded-md p-4 pt-0"
+      class="flex flex-wrap content-start gap-1 sm:gap-2 w-full max-h-40 md:h-40 overflow-y-auto overscroll-contain no-scrollbar rounded-md px-0 pb-4 pt-0 sm:px-4"
     >
       <%= for letter <- @center do %>
         <div class="hidden sm:block md:my-0">

--- a/lib/piratex_web/components/game/playing.ex
+++ b/lib/piratex_web/components/game/playing.ex
@@ -150,13 +150,15 @@ defmodule PiratexWeb.Components.Playing do
           data-pane-dot="primary"
           class="mobile-pane-dot active"
           aria-label="Show play surface"
-        ></button>
+        >
+        </button>
         <button
           type="button"
           data-pane-dot="feed"
           class="mobile-pane-dot"
           aria-label="Show history and chat"
-        ></button>
+        >
+        </button>
       </div>
     </div>
 
@@ -258,7 +260,7 @@ defmodule PiratexWeb.Components.Playing do
     ~H"""
     <%= cond do %>
       <% @visible_word_steal != nil -> %>
-        <.ps_modal title="word steal">
+        <.ps_modal title="steal" textured>
           <.word_steal
             players={@game_state.players}
             teams={@game_state.teams}
@@ -300,12 +302,12 @@ defmodule PiratexWeb.Components.Playing do
       style="pointer-events: none;"
     >
       <div
-        class="mx-4 max-w-[calc(100vw-2rem)] p-4 rounded-lg shadow-xl md:mx-0 md:p-6"
+        class="mx-2 max-w-[calc(100vw-1rem)] p-3 rounded-lg shadow-xl md:mx-0 md:max-w-lg md:p-6"
         style="pointer-events: auto; background-color: var(--theme-modal-bg); border: 2px solid var(--theme-modal-border);"
       >
-        <div class="flex flex-col gap-4 px-2 py-2 md:px-4">
+        <div class="flex flex-col gap-4 px-0 py-2 md:px-4">
           <div class="mx-auto mb-4">
-            <.tile_word word="Challenge" class="flex-wrap justify-center" />
+            <.tile_word word="Challenge" textured class="justify-center" />
           </div>
           <.challenge
             challenge={@challenge}

--- a/lib/piratex_web/components/game/playing.ex
+++ b/lib/piratex_web/components/game/playing.ex
@@ -36,29 +36,50 @@ defmodule PiratexWeb.Components.Playing do
     <% challenge_open? = ChallengeService.open_challenge?(@game_state) %>
     <div id="game_wrapper" class="flex flex-col" phx-hook="Hotkeys">
       <span id="sound_player" phx-hook="SoundPlayer" class="hidden"></span>
-      <div class="grid gap-6 md:grid-cols-[minmax(0,1fr)_260px] md:items-start md:gap-x-8 md:gap-y-8">
-        <div
-          id="main_playing_area"
-          class="contents md:relative md:col-start-1 md:row-span-2 md:flex md:min-w-0 md:flex-col md:gap-8"
+      <%!--
+        Layout track. On mobile (<md) it is `position: fixed` filling the viewport
+        below the header, with two full-viewport panes the user swipes between. On
+        desktop it becomes the existing two-column grid; the pane <section>s
+        collapse via `md:contents` so their children land directly in the grid.
+      --%>
+      <div
+        id="layout_track"
+        phx-hook="MobilePanes"
+        data-challenge-open={if challenge_open?, do: "true", else: "false"}
+        class="mobile-pane-track flex snap-x snap-mandatory overflow-x-auto overscroll-x-contain no-scrollbar md:static md:grid md:gap-6 md:grid-cols-[minmax(0,1fr)_260px] md:items-start md:gap-x-8 md:gap-y-8 md:overflow-visible md:overscroll-auto md:snap-none"
+      >
+        <%!-- Pane 1: primary play surface (tiles, action area, team words) --%>
+        <section
+          data-pane="primary"
+          class={[
+            "mobile-pane relative flex h-full shrink-0 basis-full flex-col gap-6 overflow-x-hidden overscroll-contain px-4 pt-4 pb-16 snap-start snap-always md:contents",
+            if(challenge_open?, do: "overflow-y-hidden", else: "overflow-y-auto")
+          ]}
         >
-          <div id="board_center_and_actions" class="order-1 min-w-0">
+          <div class="min-w-0 md:col-start-1 md:row-start-1">
             <.center center={@game_state.center} />
           </div>
 
-          <.challenge_panel
-            :if={challenge_open?}
-            challenge={Enum.at(@game_state.challenges, 0)}
-            player_name={@my_name}
-            watch_only={@watch_only}
-            challenge_timeout_ms={@challenge_timeout_ms}
-          />
+          <div :if={not @watch_only} class="w-full md:col-start-2 md:row-start-1">
+            <.player_action_area
+              my_name={@my_name}
+              game_state={@game_state}
+              word_form={@word_form}
+              min_word_length={@min_word_length}
+              paused={challenge_open?}
+              auto_flip={@auto_flip}
+              is_turn={@is_turn}
+              turn_timeout_ms={@turn_timeout_ms}
+              active_player_count={@game_state.active_player_count}
+            />
+          </div>
 
           <%= if @zen_mode do %>
-            <div class="order-4">
+            <div class="md:col-start-1 md:row-start-2">
               <.zen_mode game_state={@game_state} />
             </div>
           <% else %>
-            <div class="order-4">
+            <div class="md:col-start-1 md:row-start-2">
               <div class="flex flex-wrap gap-4">
                 <%= for team <- @game_state.teams do %>
                   <.team_word_area
@@ -69,24 +90,29 @@ defmodule PiratexWeb.Components.Playing do
               </div>
             </div>
           <% end %>
-        </div>
 
-        <div :if={not @watch_only} class="order-2 w-full md:col-start-2 md:row-start-1">
-          <.player_action_area
-            my_name={@my_name}
-            game_state={@game_state}
-            word_form={@word_form}
-            min_word_length={@min_word_length}
-            paused={challenge_open?}
-            auto_flip={@auto_flip}
-            is_turn={@is_turn}
-            turn_timeout_ms={@turn_timeout_ms}
-            active_player_count={@game_state.active_player_count}
+          <%!--
+            Challenge modal lives inside pane 1 so the user can swipe to pane 2 and
+            access chat while a challenge is open. On mobile it positions absolutely
+            within pane 1; on desktop it switches to fixed-viewport (pane 1's
+            md:contents removes its box, so absolute would have no anchor anyway).
+          --%>
+          <.challenge_panel
+            :if={challenge_open?}
+            challenge={Enum.at(@game_state.challenges, 0)}
+            player_name={@my_name}
+            watch_only={@watch_only}
+            challenge_timeout_ms={@challenge_timeout_ms}
           />
-        </div>
+        </section>
 
-        <%= if not @zen_mode do %>
-          <div class="order-5 flex w-full flex-col md:col-start-2 md:row-start-2">
+        <%!-- Pane 2: history + chat/activity feed --%>
+        <section
+          :if={not @zen_mode}
+          data-pane="feed"
+          class="mobile-pane flex h-full shrink-0 basis-full flex-col overflow-hidden overscroll-contain px-4 pt-4 pb-[calc(env(safe-area-inset-bottom,0px)+4rem)] snap-start snap-always md:contents md:pb-0"
+        >
+          <div class="flex min-h-0 w-full flex-1 flex-col md:col-start-2 md:row-start-2">
             <.history
               watch_only={@watch_only}
               challengeable_history={@challengeable_history}
@@ -100,9 +126,40 @@ defmodule PiratexWeb.Components.Playing do
               max_chat_message_length={@max_chat_message_length}
             />
           </div>
-        <% end %>
+        </section>
+      </div>
+
+      <%!--
+        Pane indicator dots — fixed at the bottom of the viewport on mobile so they
+        are always reachable as a tap fallback if the user can't or won't swipe.
+      --%>
+      <%!--
+        phx-update="ignore" prevents morphdom from resetting the dot classes
+        on every LiveView patch. Without it, every chat message / state update
+        snaps the active class back to whatever the server-rendered HTML says,
+        making the dot desync from the actual visible pane.
+      --%>
+      <div
+        :if={not @zen_mode}
+        id="mobile_pane_dots"
+        phx-update="ignore"
+        class="mobile-pane-dots fixed inset-x-0 bottom-3 z-30 flex justify-center gap-3 md:hidden"
+      >
+        <button
+          type="button"
+          data-pane-dot="primary"
+          class="mobile-pane-dot active"
+          aria-label="Show play surface"
+        ></button>
+        <button
+          type="button"
+          data-pane-dot="feed"
+          class="mobile-pane-dot"
+          aria-label="Show history and chat"
+        ></button>
       </div>
     </div>
+
     <.render_modal
       visible_word_steal={@visible_word_steal}
       game_state={@game_state}
@@ -231,15 +288,24 @@ defmodule PiratexWeb.Components.Playing do
   attr :challenge_timeout_ms, :integer, required: true
 
   defp challenge_panel(assigns) do
+    # Outer is a full-screen flex centerer with pointer-events: none so clicks
+    # outside the modal box pass through to underlying chat/etc. Inner box has
+    # pointer-events: auto and a max-width so it stays inside the viewport on
+    # narrow screens. Inline pointer-events styles guard against any class
+    # specificity issue in case Tailwind utility order is overridden.
     ~H"""
-    <div id="challenge_panel" class="fixed inset-0 z-40 flex items-center justify-center">
+    <div
+      id="challenge_panel"
+      class="absolute inset-0 z-[60] flex items-start justify-center pt-[15vh] md:fixed md:items-center md:pt-0"
+      style="pointer-events: none;"
+    >
       <div
-        class="p-6 rounded-lg shadow-xl z-50"
-        style="background-color: var(--theme-modal-bg); border: 2px solid var(--theme-modal-border);"
+        class="mx-4 max-w-[calc(100vw-2rem)] p-4 rounded-lg shadow-xl md:mx-0 md:p-6"
+        style="pointer-events: auto; background-color: var(--theme-modal-bg); border: 2px solid var(--theme-modal-border);"
       >
-        <div class="flex flex-col gap-4 px-4 py-2">
+        <div class="flex flex-col gap-4 px-2 py-2 md:px-4">
           <div class="mx-auto mb-4">
-            <.tile_word word="Challenge" />
+            <.tile_word word="Challenge" class="flex-wrap justify-center" />
           </div>
           <.challenge
             challenge={@challenge}

--- a/lib/piratex_web/components/game/waiting.ex
+++ b/lib/piratex_web/components/game/waiting.ex
@@ -9,6 +9,7 @@ defmodule PiratexWeb.Components.Waiting do
   attr :game_state, :map, required: true
   attr :watch_only, :boolean, default: false
   attr :my_team_id, :any, default: nil
+  attr :min_name_length, :integer, required: true
   attr :max_name_length, :integer, required: true
   attr :valid_team_name, :boolean, required: true
 
@@ -29,6 +30,7 @@ defmodule PiratexWeb.Components.Waiting do
       <%= if not @watch_only do %>
         <.render_new_team_form
           :if={length(@game_state.teams) < Config.max_teams()}
+          min_name_length={@min_name_length}
           max_name_length={@max_name_length}
           valid_team_name={@valid_team_name}
         />
@@ -45,6 +47,7 @@ defmodule PiratexWeb.Components.Waiting do
     """
   end
 
+  attr :min_name_length, :integer, required: true
   attr :max_name_length, :integer, required: true
   attr :valid_team_name, :boolean, required: true
 
@@ -64,15 +67,12 @@ defmodule PiratexWeb.Components.Waiting do
           field={:team}
           placeholder="Name"
           value=""
+          required
+          minlength={@min_name_length}
           maxlength={@max_name_length}
           class="rounded-r-none border-r-0"
         />
-        <.ps_button
-          type="submit"
-          class="rounded-l-none"
-          disabled={!@valid_team_name}
-          disabled_style={false}
-        >
+        <.ps_button type="submit" class="rounded-l-none" disabled_style={false}>
           NEW TEAM
         </.ps_button>
       </.form>

--- a/lib/piratex_web/components/partials/activity_feed_component.ex
+++ b/lib/piratex_web/components/partials/activity_feed_component.ex
@@ -11,10 +11,13 @@ defmodule PiratexWeb.Components.ActivityFeedComponent do
 
   def activity_panel(assigns) do
     ~H"""
-    <div id="activity_panel" class="relative z-50 mt-6 flex w-full flex-col">
+    <div
+      id="activity_panel"
+      class="relative z-50 mt-6 flex min-h-0 w-full flex-1 flex-col md:flex-none"
+    >
       <div
-        class="activity-feed-shell flex w-full flex-col overflow-hidden rounded-md"
-        style="background-color: transparent; height: 20rem;"
+        class="activity-feed-shell flex min-h-0 w-full flex-1 flex-col overflow-hidden rounded-md md:h-80 md:flex-none"
+        style="background-color: transparent;"
       >
         <div
           id="activity_feed"

--- a/lib/piratex_web/components/partials/challenge_component.ex
+++ b/lib/piratex_web/components/partials/challenge_component.ex
@@ -13,21 +13,21 @@ defmodule PiratexWeb.Components.ChallengeComponent do
     <div class="flex flex-col gap-4">
       <div class="flex flex-col items-center gap-2 text-center">
         <%= if @challenge.word_steal.victim_word do %>
-          <div class="flex flex-col items-center gap-3">
-            <div class="flex flex-col items-center gap-1">
+          <div class="flex w-full flex-col items-center gap-3">
+            <div class="flex w-full flex-col items-center gap-1">
               <span>Old Word</span>
-              <.tile_word word={@challenge.word_steal.victim_word} />
+              <.tile_word word={@challenge.word_steal.victim_word} scroll />
             </div>
             <div class="text-xl">↓</div>
-            <div class="flex flex-col items-center gap-1">
+            <div class="flex w-full flex-col items-center gap-1">
               <span>New Word</span>
-              <.tile_word word={@challenge.word_steal.thief_word} />
+              <.tile_word word={@challenge.word_steal.thief_word} scroll />
             </div>
           </div>
         <% else %>
-          <div class="flex flex-col items-center gap-2">
+          <div class="flex w-full flex-col items-center gap-2">
             <span>Word Under Challenge</span>
-            <.tile_word word={@challenge.word_steal.thief_word} />
+            <.tile_word word={@challenge.word_steal.thief_word} scroll />
           </div>
         <% end %>
       </div>

--- a/lib/piratex_web/components/partials/history_component.ex
+++ b/lib/piratex_web/components/partials/history_component.ex
@@ -9,7 +9,7 @@ defmodule PiratexWeb.Components.HistoryComponent do
 
   def history(assigns) do
     ~H"""
-    <div id="history_panel" class="mt-4 flex w-full flex-col md:mt-0 md:min-h-[11rem]">
+    <div id="history_panel" class="mt-4 flex w-full shrink-0 flex-col md:mt-0 md:min-h-[11rem]">
       <div :if={@challengeable_history != []} class="mx-auto mb-4 md:mx-0">
         <.tile_word word="History" textured />
       </div>

--- a/lib/piratex_web/components/partials/podium_component.ex
+++ b/lib/piratex_web/components/partials/podium_component.ex
@@ -47,7 +47,7 @@ defmodule PiratexWeb.Components.PodiumComponent do
       <% end %>
     </div>
     <%!-- Mobile --%>
-    <div class="flex flex-col gap-2 lg:hidden">
+    <div class="flex w-full flex-col gap-2 px-4 lg:hidden">
       <%= for {rank, team} <- @ranked_teams do %>
         <div class="my-2">
           <.podium_team mobile={true} team={team} players={@players} rank={rank} podium={false} />
@@ -67,7 +67,7 @@ defmodule PiratexWeb.Components.PodiumComponent do
     ~H"""
     <div
       id={"podium_team_#{@team.name}-#{if @mobile, do: "mobile", else: ""}"}
-      class="flex flex-col team-word-area min-w-48 rounded-md border-2 min-h-48 "
+      class="flex flex-col team-word-area min-w-48 max-w-full rounded-md border-2 min-h-48 "
       style="border-color: var(--theme-border);"
     >
       <div class="w-full px-auto border-b-2" style="border-color: var(--theme-border);">
@@ -76,7 +76,7 @@ defmodule PiratexWeb.Components.PodiumComponent do
           {join_players(@players, @team.id)}
         </div>
       </div>
-      <div class="flex flex-col pb-1 mx-2 mb-2 max-w-[400px] overflow-x-auto">
+      <div class="flex flex-col pb-1 mx-2 mb-2 max-w-full overflow-x-auto overscroll-x-contain no-scrollbar lg:max-w-[400px]">
         <%= for word <- Enum.sort_by(@team.words, &String.length(&1), :desc) do %>
           <div class="mt-2">
             <.tile_word word={word} />

--- a/lib/piratex_web/components/partials/stats_component.ex
+++ b/lib/piratex_web/components/partials/stats_component.ex
@@ -386,10 +386,10 @@ defmodule PiratexWeb.Components.StatsComponent do
   defp best_steal(assigns) do
     ~H"""
     <.award_box award_title="Best Steal">
-      <div class="flex flex-wrap pb-2 pt-3 gap-2 mx-auto">
-        <.tile_word :if={@victim_word} word={@victim_word} />
-        <.icon :if={@victim_word} name="hero-arrow-right-solid" class="h-8 w-8" />
-        <.tile_word word={@thief_word} />
+      <div class="flex w-full flex-nowrap items-center gap-2 overflow-x-auto overscroll-x-contain no-scrollbar pb-2 pt-3">
+        <.tile_word :if={@victim_word} word={@victim_word} class="shrink-0" />
+        <.icon :if={@victim_word} name="hero-arrow-right-solid" class="h-8 w-8 shrink-0" />
+        <.tile_word word={@thief_word} class="shrink-0" />
       </div>
     </.award_box>
     """
@@ -398,8 +398,8 @@ defmodule PiratexWeb.Components.StatsComponent do
   defp longest_word(assigns) do
     ~H"""
     <.award_box award_title="Longest Word">
-      <div class="flex flex-row pb-2 pt-3 mx-auto max-w-md gap-2 overflow-x-auto no-scrollbar">
-        <.tile_word word={@longest_word} />
+      <div class="flex w-full flex-nowrap items-center gap-2 overflow-x-auto overscroll-x-contain no-scrollbar pb-2 pt-3">
+        <.tile_word word={@longest_word} class="shrink-0" />
       </div>
     </.award_box>
     """

--- a/lib/piratex_web/components/partials/stats_component.ex
+++ b/lib/piratex_web/components/partials/stats_component.ex
@@ -386,10 +386,19 @@ defmodule PiratexWeb.Components.StatsComponent do
   defp best_steal(assigns) do
     ~H"""
     <.award_box award_title="Best Steal">
-      <div class="flex w-full flex-nowrap items-center gap-2 overflow-x-auto overscroll-x-contain no-scrollbar pb-2 pt-3">
-        <.tile_word :if={@victim_word} word={@victim_word} class="shrink-0" />
+      <%!--
+        FitRowOrStack lays this out as a row when "old -> new" fits the
+        card, and stacks it vertically (rotating the arrow down) when it
+        doesn't. Each word still scrolls individually via `scroll`.
+      --%>
+      <div
+        id="best-steal-layout"
+        phx-hook="FitRowOrStack"
+        class="flex w-full items-center justify-center gap-2 pb-2 pt-3"
+      >
+        <.tile_word :if={@victim_word} word={@victim_word} scroll />
         <.icon :if={@victim_word} name="hero-arrow-right-solid" class="h-8 w-8 shrink-0" />
-        <.tile_word word={@thief_word} class="shrink-0" />
+        <.tile_word word={@thief_word} scroll />
       </div>
     </.award_box>
     """
@@ -398,8 +407,8 @@ defmodule PiratexWeb.Components.StatsComponent do
   defp longest_word(assigns) do
     ~H"""
     <.award_box award_title="Longest Word">
-      <div class="flex w-full flex-nowrap items-center gap-2 overflow-x-auto overscroll-x-contain no-scrollbar pb-2 pt-3">
-        <.tile_word word={@longest_word} class="shrink-0" />
+      <div class="flex w-full flex-col items-center pb-2 pt-3">
+        <.tile_word word={@longest_word} scroll />
       </div>
     </.award_box>
     """

--- a/lib/piratex_web/components/partials/teams_component.ex
+++ b/lib/piratex_web/components/partials/teams_component.ex
@@ -103,8 +103,10 @@ defmodule PiratexWeb.Components.TeamsComponent do
 
   def team_name(assigns) do
     ~H"""
-    <div class="border-b-2" style="border-color: var(--theme-border);">
-      {if @is_my_team, do: "• "}{@team.name}
+    <div class="text-center">
+      <span class="inline-block border-b-2" style="border-color: var(--theme-border);">
+        {if @is_my_team, do: "• "}{@team.name}
+      </span>
     </div>
     """
   end

--- a/lib/piratex_web/components/partials/teams_component.ex
+++ b/lib/piratex_web/components/partials/teams_component.ex
@@ -4,7 +4,7 @@ defmodule PiratexWeb.Components.TeamsComponent do
   import PiratexWeb.Components.PiratexComponents
 
   attr :teams, :list, required: true
-  attr :players_teams, :list, required: true
+  attr :players_teams, :map, required: true
   attr :my_team_id, :integer, required: true
   attr :watch_only, :boolean, default: false
 
@@ -15,18 +15,11 @@ defmodule PiratexWeb.Components.TeamsComponent do
       phx-click-away="toggle_teams_modal"
     >
       <%= for team <- @teams do %>
-        <div class="flex flex-col gap-2 mx-8">
-          <.team_name team={team} is_my_team={team.id == @my_team_id} />
-          <div class="flex flex-col gap-2 mx-auto">
-            <%= for {player_name, player_team_id} <- @players_teams do %>
-              <%= if player_team_id == team.id do %>
-                <div>
-                  {player_name}
-                </div>
-              <% end %>
-            <% end %>
-          </div>
-        </div>
+        <.team_roster_area
+          team={team}
+          players_teams={@players_teams}
+          is_my_team={team.id == @my_team_id}
+        />
       <% end %>
     </div>
 
@@ -48,23 +41,20 @@ defmodule PiratexWeb.Components.TeamsComponent do
     <div class="my-8">
       <div class="flex flex-col sm:flex-row justify-around gap-4">
         <%= for team <- @teams do %>
-          <div class="my-4 mx-auto">
-            <.team_name team={team} is_my_team={team.id == @my_team_id} />
-            <div class="my-4 mx-auto">
-              <ul class="list-decimal my-4">
-                <%= for {player_name, team_id} when team_id == team.id <- @players_teams do %>
-                  <li>{player_name}</li>
-                <% end %>
-              </ul>
+          <div class="my-4 mx-auto flex flex-col items-center gap-4">
+            <.team_roster_area
+              team={team}
+              players_teams={@players_teams}
+              is_my_team={team.id == @my_team_id}
+            />
 
-              <%= if not @watch_only do %>
-                <div class="flex sm:hidden">
-                  <%= if team.id != @my_team_id do %>
-                    <.join_team_form team_id={team.id} />
-                  <% end %>
-                </div>
-              <% end %>
-            </div>
+            <%= if not @watch_only do %>
+              <div class="flex sm:hidden">
+                <%= if team.id != @my_team_id do %>
+                  <.join_team_form team_id={team.id} />
+                <% end %>
+              </div>
+            <% end %>
           </div>
         <% end %>
       </div>
@@ -72,7 +62,7 @@ defmodule PiratexWeb.Components.TeamsComponent do
       <%= if not @watch_only do %>
         <div class="flex-row hidden sm:flex justify-around gap-4">
           <%= for team <- @teams do %>
-            <div class="w-8">
+            <div class="flex min-w-48 justify-center">
               <%= if team.id != @my_team_id do %>
                 <.join_team_form team_id={team.id} />
               <% else %>
@@ -82,6 +72,32 @@ defmodule PiratexWeb.Components.TeamsComponent do
           <% end %>
         </div>
       <% end %>
+    </div>
+    """
+  end
+
+  attr :team, :map, required: true
+  attr :players_teams, :map, required: true
+  attr :is_my_team, :boolean, required: true
+
+  defp team_roster_area(assigns) do
+    ~H"""
+    <div
+      class="team-word-area flex min-h-40 min-w-48 flex-col rounded-md border-2"
+      style="border-color: var(--theme-border); color: var(--theme-text);"
+    >
+      <div
+        class="team-name-button w-full border-b-2 px-4 py-1 text-center font-semibold"
+        style="border-color: var(--theme-border);"
+      >
+        {if @is_my_team, do: "• "}{@team.name}
+      </div>
+
+      <ol class="mx-8 my-4 list-decimal space-y-2">
+        <%= for {player_name, team_id} when team_id == @team.id <- @players_teams do %>
+          <li>{player_name}</li>
+        <% end %>
+      </ol>
     </div>
     """
   end

--- a/lib/piratex_web/components/partials/word_steal_component.ex
+++ b/lib/piratex_web/components/partials/word_steal_component.ex
@@ -10,11 +10,11 @@ defmodule PiratexWeb.Components.WordStealComponent do
         Thief: {thief_name(@players, @word_steal)} ({thief_team_name(@teams, @word_steal)})
       </div>
       <%= if @word_steal.victim_word do %>
-        Old Word: <.tile_word word={@word_steal.victim_word} /> New Word:
+        Old Word: <.tile_word word={@word_steal.victim_word} scroll /> New Word:
       <% else %>
         Word:
       <% end %>
-      <.tile_word word={@word_steal.thief_word} />
+      <.tile_word word={@word_steal.thief_word} scroll />
       <div class="mt-4 mx-auto">
         <.ps_button phx-click="hide_word_steal">
           DONE

--- a/lib/piratex_web/components/piratex_components.ex
+++ b/lib/piratex_web/components/piratex_components.ex
@@ -11,14 +11,20 @@ defmodule PiratexWeb.Components.PiratexComponents do
   attr :size, :string, default: "md"
   attr :class, :string, default: ""
   attr :textured, :boolean, default: false
+  attr :scroll, :boolean, default: false
 
   @doc """
   Renders a word with tiles. Pass `textured: true` to use the wood-grain
-  textured tile variant (used for titles).
+  textured tile variant (used for titles). Pass `scroll: true` to let a
+  long word scroll horizontally instead of overflowing its container.
   """
   def tile_word(assigns) do
     ~H"""
-    <div class={"flex flex-row #{@class}"}>
+    <div class={[
+      "flex flex-row",
+      @scroll && "min-w-0 max-w-full overflow-x-auto overscroll-x-contain no-scrollbar",
+      @class
+    ]}>
       <%= for letter <- String.graphemes(String.upcase(@word)) do %>
         <%= case @size do %>
           <% "lg" -> %>
@@ -263,6 +269,7 @@ defmodule PiratexWeb.Components.PiratexComponents do
   end
 
   attr :title, :string, required: true
+  attr :textured, :boolean, default: false
   slot :inner_block, required: true
 
   def ps_modal(assigns) do
@@ -272,12 +279,12 @@ defmodule PiratexWeb.Components.PiratexComponents do
       style="background-color: var(--theme-modal-overlay);"
     >
       <div
-        class="p-6 rounded-lg shadow-xl z-50"
+        class="mx-2 max-w-[calc(100vw-1rem)] p-6 rounded-lg shadow-xl z-50 md:mx-0 md:max-w-lg"
         style="background-color: var(--theme-modal-bg); border: 2px solid var(--theme-modal-border);"
       >
         <div class="flex flex-col gap-4 px-4 py-2">
           <div class="mx-auto mb-4">
-            <.tile_word word={@title} />
+            <.tile_word word={@title} textured={@textured} />
           </div>
           {render_slot(@inner_block)}
         </div>

--- a/lib/piratex_web/components/piratex_components.ex
+++ b/lib/piratex_web/components/piratex_components.ex
@@ -319,6 +319,7 @@ defmodule PiratexWeb.Components.PiratexComponents do
   attr :max_width, :string, default: "max-w-48"
   attr :minlength, :integer, default: nil
   attr :maxlength, :integer, default: nil
+  attr :required, :boolean, default: false
   attr :autofocus, :boolean, default: false
   attr :rest, :global, include: ~w(phx-debounce)
 
@@ -332,6 +333,7 @@ defmodule PiratexWeb.Components.PiratexComponents do
       type={@type}
       placeholder={@placeholder}
       autocomplete={if @autocomplete, do: "on", else: "off"}
+      required={@required}
       minlength={@minlength}
       maxlength={@maxlength}
       autofocus={@autofocus}

--- a/lib/piratex_web/endpoint.ex
+++ b/lib/piratex_web/endpoint.ex
@@ -27,11 +27,18 @@ defmodule PiratexWeb.Endpoint do
   #
   # You should set gzip to true if you are running phx.digest
   # when deploying your static files in production.
+  # `cache_control_for_etags` is env-dependent: prod caches static assets
+  # hard (filenames are digested, so stale content is impossible), while
+  # dev uses "no-cache" so the browser must revalidate every request. The
+  # server still answers 304 for unchanged files via etags, but a changed
+  # file (e.g. app.css after an edit) is always re-fetched — no stale CSS
+  # when testing on a real device.
   plug Plug.Static,
     at: "/",
     from: :piratex,
     gzip: true,
-    cache_control_for_etags: "public, max-age=7776000",
+    cache_control_for_etags:
+      Application.compile_env(:piratex, :static_cache_control, "public, max-age=7776000"),
     only: PiratexWeb.static_paths()
 
   # Code reloading can be explicitly enabled under the

--- a/lib/piratex_web/live/about.ex
+++ b/lib/piratex_web/live/about.ex
@@ -59,7 +59,7 @@ defmodule PiratexWeb.Live.About do
 
   defp render_how_to_play(assigns) do
     ~H"""
-    <.tile_word class="mx-auto my-4" word="how to play" textured />
+    <.tile_word class="mx-auto my-4" word="overview" textured />
     <ul class="list-disc ml-5">
       <%= for step <- how_to_play() do %>
         <li class="text-lg mb-1">{step}</li>

--- a/lib/piratex_web/live/find.ex
+++ b/lib/piratex_web/live/find.ex
@@ -61,7 +61,7 @@ defmodule PiratexWeb.Live.Find do
 
       <div class="flex flex-col w-full">
         <%= if length(@games) != 0 do %>
-          <.tile_word word="Games" class="my-8 mx-auto" />
+          <.tile_word word="Games" textured class="my-8 mx-auto" />
           <%= for game <- @games do %>
             <.link class="mx-auto" href={~p"/game/#{game.id}/join"}>
               {game.id} ({length(game.players)})

--- a/lib/piratex_web/live/game.ex
+++ b/lib/piratex_web/live/game.ex
@@ -48,8 +48,8 @@ defmodule PiratexWeb.Live.Game do
           challenge_timeout_ms: Config.challenge_timeout_ms(),
           # TODO: validate team name
           valid_team_name: false,
-          min_name_length: Config.min_player_name(),
-          max_name_length: Config.max_player_name(),
+          min_name_length: Config.min_team_name(),
+          max_name_length: Config.max_team_name(),
           zen_mode: false,
           auto_flip: false,
           show_teams_modal: false,
@@ -107,6 +107,7 @@ defmodule PiratexWeb.Live.Game do
         <.waiting
           game_state={@game_state}
           my_team_id={@my_team_id}
+          min_name_length={@min_name_length}
           max_name_length={@max_name_length}
           valid_team_name={@valid_team_name}
         />

--- a/lib/piratex_web/live/rules.ex
+++ b/lib/piratex_web/live/rules.ex
@@ -127,11 +127,11 @@ defmodule PiratexWeb.Live.Rules do
 
         <p>If the following letters are in the center, a player can submit the word "cat".</p>
 
-        <div class="flex flex-row gap-4">
+        <div class="flex flex-col items-center gap-4 md:flex-row">
           <.tile_word word="a" />
           <.tile_word word="c" />
           <.tile_word word="t" />
-          <.icon name="hero-arrow-right-solid" class="h-8 w-8" />
+          <.icon name="hero-arrow-right-solid" class="h-8 w-8 shrink-0 rotate-90 md:rotate-0" />
           <.tile_word word="cat" />
         </div>
 
@@ -140,11 +140,11 @@ defmodule PiratexWeb.Live.Rules do
           is flipped into the center, any player can submit the word "pact".
         </p>
 
-        <div class="flex flex-row gap-4">
+        <div class="flex flex-col items-center gap-4 md:flex-row">
           <.tile_word word="cat" />
-          <.icon name="hero-plus-solid" class="h-8 w-8" />
+          <.icon name="hero-plus-solid" class="h-8 w-8 shrink-0" />
           <.tile_word word="p" />
-          <.icon name="hero-arrow-right-solid" class="h-8 w-8" />
+          <.icon name="hero-arrow-right-solid" class="h-8 w-8 shrink-0 rotate-90 md:rotate-0" />
           <.tile_word word="pact" />
         </div>
 
@@ -156,12 +156,12 @@ defmodule PiratexWeb.Live.Rules do
           NOTE: due to rule #4, if an "s" had been flipped instead of a "p", the following steal would not be allowed:
         </p>
 
-        <div class="flex flex-row gap-4">
-          <p class="block my-auto">INVALID:</p>
+        <div class="flex flex-col items-center gap-4 md:flex-row">
+          <p class="my-auto">INVALID:</p>
           <.tile_word word="cat" />
-          <.icon name="hero-plus-solid" class="h-8 w-8" />
+          <.icon name="hero-plus-solid" class="h-8 w-8 shrink-0" />
           <.tile_word word="s" />
-          <.icon name="hero-arrow-right-solid" class="h-8 w-8" />
+          <.icon name="hero-arrow-right-solid" class="h-8 w-8 shrink-0 rotate-90 md:rotate-0" />
           <.tile_word word="cats" />
         </div>
 
@@ -169,12 +169,12 @@ defmodule PiratexWeb.Live.Rules do
           However, the word "acts" would be a valid steal from "cat", because they do not share an English root word.
         </p>
 
-        <div class="flex flex-row gap-4">
-          <p class="block my-auto">VALID:</p>
+        <div class="flex flex-col items-center gap-4 md:flex-row">
+          <p class="my-auto">VALID:</p>
           <.tile_word word="cat" />
-          <.icon name="hero-plus-solid" class="h-8 w-8" />
+          <.icon name="hero-plus-solid" class="h-8 w-8 shrink-0" />
           <.tile_word word="s" />
-          <.icon name="hero-arrow-right-solid" class="h-8 w-8" />
+          <.icon name="hero-arrow-right-solid" class="h-8 w-8 shrink-0 rotate-90 md:rotate-0" />
           <.tile_word word="acts" />
         </div>
       </div>

--- a/lib/piratex_web/live/watch.ex
+++ b/lib/piratex_web/live/watch.ex
@@ -35,6 +35,7 @@ defmodule PiratexWeb.Live.WatchGame do
           challenge_timeout_ms: Config.challenge_timeout_ms(),
           show_teams_modal: false,
           show_hotkeys_modal: false,
+          min_name_length: Config.min_team_name(),
           max_name_length: 0,
           valid_team_name: false,
           zen_mode: false,
@@ -63,6 +64,7 @@ defmodule PiratexWeb.Live.WatchGame do
           game_state={@game_state}
           watch_only={true}
           my_team_id={@my_team_id}
+          min_name_length={@min_name_length}
           max_name_length={@max_name_length}
           valid_team_name={@valid_team_name}
         />

--- a/test/live/playing_activity_feed_test.exs
+++ b/test/live/playing_activity_feed_test.exs
@@ -32,7 +32,6 @@ defmodule PiratexWeb.PlayingActivityFeedTest do
       {:ok, view, _html} = live(conn, ~p"/game/#{game_id}")
 
       assert has_element?(view, "#challenge_panel")
-      assert has_element?(view, "#main_playing_area #challenge_panel")
       assert has_element?(view, "#activity_panel")
       assert has_element?(view, "#chat_message_input")
     end


### PR DESCRIPTION
## Summary

Adds a mobile two-pane swipe layout for the game screen and a round of mobile/desktop polish on top of it.

**Layout**
- `MobilePanes` hook drives a two-pane swipe layout: a scroll-snap track on mobile that collapses into the existing two-column grid on desktop, with dot indicators.
- On mobile the header is fixed and the body locked, so dragging scrolls a pane internally instead of sliding the navbar on/off screen.

**Modals**
- Challenge modal: trimmed mobile padding, capped desktop width (`md:max-w-lg`); same desktop cap for `ps_modal`.
- Long words in the challenge/steal modals scroll horizontally via a new `tile_word` `scroll` option instead of overflowing.
- Textured tiles for the "Challenge"/"steal" modal titles and the "Games" heading.

**Stats**
- Best Steal lays out as a row when "old to new" fits the card and stacks vertically when it doesn't (`FitRowOrStack` hook); each word scrolls individually.

**Dev tooling**
- Static assets are served with `cache-control: no-cache` in dev so edited CSS/JS is picked up without fighting the browser cache.
- Toolchain bumped to Elixir 1.19.5-otp-28 / Erlang 28.5.

## Test plan
- [ ] Swipe between panes on a phone; dot indicators track the active pane
- [ ] Focus the chat input on iOS — no zoom
- [ ] Open a challenge with a long word on mobile and desktop — modal stays in bounds, word scrolls
- [ ] End a game and check Best Steal row/stack behavior at narrow and wide widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
